### PR TITLE
Better exception handling and error reporting

### DIFF
--- a/lib/clibuddy/builder.rb
+++ b/lib/clibuddy/builder.rb
@@ -28,11 +28,11 @@ module CLIBuddy
     end
 
     def parse_error!(parser, message)
-      puts "Parse Error"
-      puts "  Line: #{parser.lineno}"
-      puts "  Error: #{message}"
-      puts " Lib Source: #{caller(1, 1)}"
-      exit 1
+      # TODO specific exceptions or at least error numbers
+      # TODO - clean up exceptions to differentiate between parse errors and build errors
+      # # TODO just include parser in the exceptin instead of
+      # splitting out line/token info?
+      raise Prototype::Parser::Errors::ParseError.new(parser.lineno, parser.current_token, message)
     end
 
     def parse(p)
@@ -311,7 +311,7 @@ module CLIBuddy
         when ".show-usage"
           t = p.advance_token
           if t != :EOL
-            raise "Line #{lineno}: unexpected text '#{t}' after .show-usage"
+            parse_error! p, "Unexpected etext #{t} after '.show-usage'"
           end
         else
           parse_error! p, "Unknown directive #{action.directive}"

--- a/lib/clibuddy/generator.rb
+++ b/lib/clibuddy/generator.rb
@@ -1,6 +1,6 @@
 require "clibuddy/builder"
 require "fileutils"
-
+require "clibuddy/runner/errors"
 module CLIBuddy
   class Generator
     def initialize(builder, command_name)
@@ -8,12 +8,10 @@ module CLIBuddy
       @command_name = command_name
     end
 
-
     def generate
       cmd = @builder.lookup_command(@command_name)
       if !cmd
-        # TODO raise to handler
-        puts "The command '#{@command_name}' does not exist"
+        raise Runner::Errors::NoSuchCommand.new(@command_name)
         exit 1
       end
       content = command_content(@command_name)

--- a/lib/clibuddy/main.rb
+++ b/lib/clibuddy/main.rb
@@ -1,14 +1,19 @@
 require "clibuddy/builder"
 require "clibuddy/runner"
 require "clibuddy/generator"
+require "clibuddy/parser/errors"
+require "clibuddy/runner/errors"
+require "tty/table"
+
 
 module CLIBuddy
   class Main
     def run(action, cmd_name, args)
+      @descriptor_file = "sample.txt"
       # TODO actual good handling for args, defintion file, etc.
       b = CLIBuddy::Builder.new()
       b.load("sample.txt")
-
+      @exit_code = 1
       case action
       when "generate"
         generator = CLIBuddy::Generator.new(b, cmd_name)
@@ -23,7 +28,48 @@ module CLIBuddy
         puts ""
         puts "Usage: clibuddy run COMMAND ARGUMENTS..."
         puts "       clibuddy generate COMMAND"
+        exit 1
       end
+      @exit_code = 0
+
+    rescue Prototype::Parser::Errors::SourceError => e
+      puts source_parse_error(e)
+    rescue Runner::Errors::EngineRuntimeError => e
+      puts cli_buddy_error(e)
+    ensure
+      exit @exit_code
+    end
+    def source_parse_error(e)
+      p = Pastel.new
+      t = TTY::Table.new()
+      t << [p.bold("Error Code "), e.id]
+      t << [p.bold("File "), @descriptor_file]
+      t << [p.bold("Line "), e.line_no]
+      t << ["", ""]
+      message = if e.token == :EOL || e.message.include?(e.token)
+                  e.message
+                else
+                  "Near #{e.token}: #{e.message}"
+                end
+      t << [p.bold("Message "), message]
+      msg = p.bold("File Parsing Error\n")
+      msg << t.render(:unicode,
+                      column_widths: [0, 40],
+                      alignments: [:right, :left],
+                      multiline: true, resize: true )
+      msg
+    end
+
+    def cli_buddy_error(e)
+      p = Pastel.new
+      t = TTY::Table.new()
+      t << [p.bold("Error Code "), e.id]
+      t << [p.bold("File "), @descriptor_file]
+      t << [p.bold("Message "), e.message]
+      msg = p.bold("Runtime Error\n")
+      msg << t.render(:unicode, column_widths: [0, 40],
+                      alignments: [:right, :left], multiline: true, resize: true )
+      msg
     end
   end
 end

--- a/lib/clibuddy/parser/errors.rb
+++ b/lib/clibuddy/parser/errors.rb
@@ -4,40 +4,51 @@ module CLIBuddy
       module Errors
         class SourceError < Exception
           attr_reader :message, :id
+
           def initialize(id, source_line, message)
             @message = message
             @source_line = source_line
             @id = id
           end
 
-          def line_number
+          def line_no
             @source_line.number
           end
 
-          def active_token
+          def token
             @source_line.current_token
-          end
-
-          def to_s
-            "Error: #{name}\nLine #{line_number}, near #{active_token}:\n\n #{message}"
           end
         end
 
         class NoChildrenError < SourceError
           def initialize(source_line)
-            super("CLISE001", source_line, message)
+            super("CLIPARSE001", source_line, message)
           end
         end
 
         class NotCompleteError < SourceError
           def initialize(source_line)
-            super("CLISE002", source_line, "Expected end-of-line here, instead I see '#{source_line.peek}'")
+            super("CLIPARSE002", source_line, "Expected end-of-line here, instead I see '#{source_line.peek}'")
           end
         end
 
         class NoNextTokenError < SourceError
           def initialize(source_line)
-            super("CLISE003", source_line, "Unexpected end of line.")
+            super("CLIPARSE003", source_line, "Unexpected end of line.")
+          end
+        end
+        class ParseError < SourceError
+          def initialize(line_no, token, message)
+            @line_no = line_no
+            @token = token
+            super("CLIPARSE999", nil, message)
+          end
+          def line_no
+            @line_no
+          end
+
+          def token
+            @token
           end
         end
       end

--- a/lib/clibuddy/runner/errors.rb
+++ b/lib/clibuddy/runner/errors.rb
@@ -1,0 +1,36 @@
+module CLIBuddy
+  class Runner
+    module Errors
+
+      class EngineRuntimeError < Exception
+        attr_reader :id, :message
+        def initialize(id, message)
+          @id = id
+          @message = message
+        end
+      end
+
+      class NoMatchingFlow < EngineRuntimeError
+        attr_reader :cmd_name, :given_args
+        def initialize(cmd_name, given_args)
+          @cmd_name = cmd_name
+          @given_args = given_args
+          msg = "I could not find a flow defined for #{cmd_name} which matches '#{given_args.join(" ")}'.\n"
+          msg << "Try adding a default flow handler of 'flow ANY' to avoid this message' "
+          super("CLIRUN001", msg)
+        end
+      end
+      class NoSuchCommand < EngineRuntimeError
+        attr_reader :cmd_name
+        def initialize(cmd_name)
+          msg = "I could not find any command named '#{cmd_name}'"
+          @cmd_name = cmd_name
+          super("CLIRUN002", msg)
+        end
+      end
+    end
+  end
+end
+
+
+


### PR DESCRIPTION
Turning this: 
![before](https://user-images.githubusercontent.com/1130204/36277886-2e0980e6-1260-11e8-986a-3927cb0e1e7b.png)
Into this: 
![after](https://user-images.githubusercontent.com/1130204/36277905-34920b7c-1260-11e8-8871-08f9bf8c34f9.png)
This gives a distinctly different format from the `.show-error` directive, making it clear that an  internal parse or runtime error is a different beast than the error we output from `.show-error`
