### PR TITLE
Handle common cases in arg validation

### DIFF
--- a/lib/clibuddy/runner.rb
+++ b/lib/clibuddy/runner.rb
@@ -159,7 +159,12 @@ module CLIBuddy
         # A: we can do differently-formatted exception handling that makes it clear.
         raise Errors::NoSuchCommand.new(name)
       end
-      InterpretedCommand.new(cmd, provided_args)
+      begin
+        InterpretedCommand.new(cmd, provided_args)
+      rescue OptionParser::ParseError => e
+        puts "Could not parse the arguments provided to '#{cmd.name}': #{e.message}"
+        exit 1
+      end
     end
 
     def lookup_flow

--- a/lib/clibuddy/runner/errors.rb
+++ b/lib/clibuddy/runner/errors.rb
@@ -20,6 +20,7 @@ module CLIBuddy
           super("CLIRUN001", msg)
         end
       end
+
       class NoSuchCommand < EngineRuntimeError
         attr_reader :cmd_name
         def initialize(cmd_name)
@@ -31,6 +32,3 @@ module CLIBuddy
     end
   end
 end
-
-
-


### PR DESCRIPTION
```
[clibuddy]$ be bin/clibuddy run chef-do --help=arg
Could not parse the arguments provided to 'chef-do': needless argument: --help=arg
```