### PR TITLE
Add a '.use' directive.

### DIFF
--- a/lib/clibuddy/builder.rb
+++ b/lib/clibuddy/builder.rb
@@ -300,6 +300,15 @@ module CLIBuddy
         action.parent = parent_action
         action.directive = p.advance_token
         case p.current_token
+        when ".use"
+          # Special case.  Also note this must be top level after 'for' so
+          # we will probably want to do something about that.
+          remaining = p.consume_to_eol
+          if remaining == :EOL
+            parse_error! p, "Expected matching argument list after 'for'"
+          end
+          action.args = remaining
+
         when ".spinner"
           action.msg = p.consume_to_eol
           action.children = parse_flow_actions(p.parser_from_children, action)


### PR DESCRIPTION
When present as the first action under a flow,
it allows you to specify a different flow match
to pull in and run.

ex:
```
for test0
 .show-text hello

for test1
 .use test0
```

```
$ mycmd test1
hello

$ _
```
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>