### PR TITLE
Support for replacing args specified to flags

### DIFF
--- a/lib/clibuddy/builder.rb
+++ b/lib/clibuddy/builder.rb
@@ -359,11 +359,12 @@ module CLIBuddy
           #
           # Anyway, I'm all about quick for now because our reference file has no such errors...
           action.children = parse_flow_actions(p.parser_from_children, flow, action)
-        when ".show-error"
+        when /^[.](show-error|show-message)$/
+          t = p.current_token
           action.args = p.advance_token
           # TODO validate form of error identifier
           if action.args == :EOL
-            parse_error! p, "Expected message identifier after '.show-error'"
+            parse_error! p, "Expected message identifier after '#{t}'"
           end
         when ".show-usage"
           t = p.advance_token

--- a/lib/clibuddy/runner.rb
+++ b/lib/clibuddy/runner.rb
@@ -197,8 +197,12 @@ module CLIBuddy
       @screen_working_width ||= [TTY::Screen.width, 80].min
     end
 
-    def do_show_error(action)
+    def do_show_message(action)
       puts format(lookup_message(action.args))
+    end
+
+    def do_show_error(action)
+      do_show_message(action)
     end
 
     def do_show_usage(_action)

--- a/lib/clibuddy/runner/errors.rb
+++ b/lib/clibuddy/runner/errors.rb
@@ -36,6 +36,13 @@ module CLIBuddy
           super("CLIRUN003", msg)
         end
       end
+
+      class CaptureNameSpecifiedMultipleTimes < EngineRuntimeError
+        def initialize(name)
+          msg = "You cannot specify the capture name '#{name}' twice"
+          super("CLIRUN004", msg)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If a command has a flag like
```
--*config PATH
  user to authenticate as
```

We will now replace `PATH` instances in messages. This is in addition to existing support for captured non-flag arguments.